### PR TITLE
Fix issue #59

### DIFF
--- a/src/js/custombox.js
+++ b/src/js/custombox.js
@@ -417,6 +417,7 @@ var Custombox = (function () {
                 }
 
                 if ( typeof _cache.settings[_cache.item].close === 'function' ) {
+                    _cache.open[_cache.item] = undefined;
                     _cache.settings[_cache.item].close.call();
                 }
 


### PR DESCRIPTION
This patch fixes only one situation when 'complete' event was called.
If 'complete' event don't called then on next call it don't work.
Need more test maybe.
